### PR TITLE
feat: Removed script tags in excalidraw lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@babel/preset-env": "^7.14.2",
     "@babel/preset-react": "^7.13.13",
     "@babel/preset-typescript": "^7.13.0",
-    "@excalidraw/excalidraw": "^0.16.1",
+    "@excalidraw/excalidraw": "0.16.1",
     "@types/jest": "^29.5.7",
     "@types/react": "^17.0.6",
     "@types/react-dom": "^17.0.5",

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -191,7 +191,7 @@ module.exports = {
           globOptions: {
             dot: true,
             // The built lib external-libs/exccalidraw.production.js is one single file, no need to copy chunks.
-            ignore: ["**/vendor-*.js*"],
+            ignore: ["**/vendor-*.js*", "**/locales/**"],
           },
           to: "assets/excalidraw-assets",
           toType: "dir",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -188,7 +188,7 @@ module.exports = {
           globOptions: {
             dot: true,
             // The built lib external-libs/exccalidraw.production.js is one single file, no need to copy chunks.
-            ignore: ["**/vendor-*.js*"],
+            ignore: ["**/vendor-*.js*", "**/locales/**"],
           },
           to: "assets/excalidraw-assets",
           toType: "dir",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1394,7 +1394,7 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.52.0.tgz#78fe5f117840f69dc4a353adf9b9cd926353378c"
   integrity sha512-mjZVbpaeMZludF2fsWLD0Z9gCref1Tk4i9+wddjRvpUNqqcndPkBD09N/Mapey0b3jaXbLm2kICwFv2E64QinA==
 
-"@excalidraw/excalidraw@^0.16.1":
+"@excalidraw/excalidraw@0.16.1":
   version "0.16.1"
   resolved "https://registry.yarnpkg.com/@excalidraw/excalidraw/-/excalidraw-0.16.1.tgz#a928945d567a1f5c0aa75bd1b1c05b50329eb27a"
   integrity sha512-4zirHk7dNx6SVq2jQmYOLliqAa1h3WPVqHM5qtJyhD769VsOqwlkopAcnZMb3G1PeIMm6cf2F31quS5MVqvoOQ==


### PR DESCRIPTION
This is an intent to fix issue of chrome extension review rejection.

From [https://developer.chrome.com/docs](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-overview/#remotely-hosted-code:~:text=Remotely%20hosted%20code%20is%20no%20longer%20allowed%3B%20an%20extension%20can%20only%20execute%20JavaScript%20that%20is%20included%20within%20its%20package.)
> [Remotely hosted code](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-overview/#remotely-hosted-code) is no longer allowed; an extension can only execute JavaScript that is included within its package.

Ecalidraw supports embedding some extenals websites by injecting  `<script` tags.
I removed those tags from the build using [this config](https://github.com/dantecalderon/excalidraw/pull/2). 

With this change screenshots for embeeding won't work, instead it shows an empty rectangle. But even leaving the embedding code it also don't work since the webpage take time to load and excalidraws don't wait to load.

I don't think taking screenshot of webpages is not the priority for this extension. 

By doing this we expect pass the review. @atharvakadlag Can we send this and see if the review pass?
I will continue investigating in any case.


