### PR TITLE
fix: Delegate zip validation to JSZip

### DIFF
--- a/src/components/ImpExp/ImpExp.component.tsx
+++ b/src/components/ImpExp/ImpExp.component.tsx
@@ -60,7 +60,7 @@ export function ImpExp() {
 
       const file = event.target.files[0];
 
-      XLogger.info(
+      XLogger.debug(
         "File selected: " +
           JSON.stringify({
             fileName: file.name,

--- a/src/components/ImpExp/ImpExp.component.tsx
+++ b/src/components/ImpExp/ImpExp.component.tsx
@@ -60,15 +60,13 @@ export function ImpExp() {
 
       const file = event.target.files[0];
 
-      const isZipFile =
-        file.name.toLocaleLowerCase().endsWith(".zip") &&
-        file.type === "application/zip";
-
-      if (!isZipFile) {
-        XLogger.error("Invalid file type");
-
-        return;
-      }
+      XLogger.info(
+        "File selected: " +
+          JSON.stringify({
+            fileName: file.name,
+            fileType: file.type,
+          })
+      );
 
       const reader = new FileReader();
       reader.readAsArrayBuffer(file);

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -2,7 +2,7 @@ import Logger from "js-logger";
 
 Logger.useDefaults();
 Logger.setLevel(
-  process.env.NODE_ENV === "production" ? Logger.ERROR : Logger.DEBUG
+  process.env.NODE_ENV === "production" ? Logger.WARN : Logger.DEBUG
 );
 
 export const XLogger = Logger;


### PR DESCRIPTION
This is an attempt to fix the issue of validating zip file(https://github.com/atharvakadlag/excalisave/issues/4#issuecomment-2162929558).
Seems there are differences on mimetype across differentes browsers or OSs, 
remove custom validation of mimetype and use JSZip to open the file, it wil throw error if file is not a valid zip.